### PR TITLE
fix typo in italics tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ and its handling rules. Here is the excerpt from the default parser for `brace`s
 ```elixir
   brace: %{
     "*" => %{tag: :b},
-    "_" => %{tag: :it},
+    "_" => %{tag: :i},
     "**" => %{tag: :strong, attributes: %{class: "nota-bene"}},
     "__" => %{tag: :em},
     "~" => %{tag: :s},

--- a/lib/md.ex
+++ b/lib/md.ex
@@ -27,7 +27,7 @@ defmodule Md do
       "<b>bold</b>"
 
       iex> Md.generate("It’s all *bold* and _italic_!", format: :none)
-      "<p>It’s all <b>bold</b> and <it>italic</it>!</p>"
+      "<p>It’s all <b>bold</b> and <i>italic</i>!</p>"
 
   """
   @impl Md.Parser

--- a/lib/md/parser/default.ex
+++ b/lib/md/parser/default.ex
@@ -110,7 +110,7 @@ defmodule Md.Parser.Default do
       ] ++ Enum.map(0..@ol_max, &{"#{&1}. ", %{tag: :li, outer: :ol}}),
     brace: [
       {"*", %{tag: :b}},
-      {"_", %{tag: :it}},
+      {"_", %{tag: :i}},
       {"**", %{tag: :strong, attributes: %{class: "red"}}},
       {"__", %{tag: :em}},
       {"~", %{tag: :s}},

--- a/test/md_test.exs
+++ b/test/md_test.exs
@@ -12,7 +12,7 @@ defmodule MdTest do
                   "\n",
                   {:b, nil, ["foo ", {:strong, %{class: "red"}, ["bar baz "]}]}
                 ]},
-               {:p, nil, ["Answer: ", {:it, nil, ["42"]}, "."]}
+               {:p, nil, ["Answer: ", {:i, nil, ["42"]}, "."]}
              ]
            } = Md.parse("   he\\*llo \n  *foo **bar baz \n\n Answer: _42_.")
   end
@@ -371,7 +371,7 @@ defmodule MdTest do
                {:ul, nil,
                 [
                   {:li, nil, ["1 | ", {:b, nil, ["foo"]}, " foo"]},
-                  {:li, nil, ["1 | bar ", {:it, nil, ["bar"]}]},
+                  {:li, nil, ["1 | bar ", {:i, nil, ["bar"]}]},
                   {:ul, nil,
                    [
                      {:li, nil, ["2 | baz"]},


### PR DESCRIPTION
Fix small type in the italics tag, it should be `<i>`, instead of `<it>`