### PR TITLE
Escape html chars in code blocks

### DIFF
--- a/lib/md/parser/engine.ex
+++ b/lib/md/parser/engine.ex
@@ -516,9 +516,20 @@ defmodule Md.Engine do
                <<x::utf8, rest::binary>>,
                %Md.Parser.State{path: [unquote_splicing(closing_match) | _]} = state
              ) do
-          do_parse(rest, push_char(state, x))
+          do_parse(rest, push_char(state, escape_char(x)))
         end
       end)
+
+      defp escape_char(x) do
+        case x do
+          ?' -> "&#39;"
+          ?" -> "&quot;"
+          ?& -> "&amp;"
+          ?< -> "&lt;"
+          ?> -> "&gt;"
+          _ -> x
+        end
+      end
     end
   end
 

--- a/test/md_test.exs
+++ b/test/md_test.exs
@@ -199,6 +199,23 @@ defmodule MdTest do
     """
 
     assert [{:pre, nil, [{:code, nil, ["`inline-code`\n"]}]}] == Md.parse(input).ast
+
+    input = """
+    ```html
+    <div>
+      <p>foo</p>
+    </div>
+    ```
+    """
+
+    assert [
+             {:pre, nil,
+              [
+                {:code, %{class: "html"},
+                 ["&lt;div&gt;\n  &lt;p&gt;foo&lt;/p&gt;\n&lt;/div&gt;\n"]}
+              ]}
+           ] ==
+             Md.parse(input).ast
   end
 
   test "codeblock" do


### PR DESCRIPTION
Escapes html tags in code blocks, I think this is the correct way of handling it. For reference, this is also how Earmark works. I'm new to this library - if there is a better way of handling this, let me know!

## Example

    ```html
    <div>
      foo
    </div>
    ```

Parses to:
```elixir
[{:pre, nil, [{:code, %{class: "html"}, ["&lt;div&gt;\n  foo\n&lt;/div&gt;\n"]}]}]
```
